### PR TITLE
Provide #reference_required?, needed for JRuby

### DIFF
--- a/lib/ffi/bit_masks/bit_mask.rb
+++ b/lib/ffi/bit_masks/bit_mask.rb
@@ -182,6 +182,9 @@ module FFI
         return flags
       end
 
+      def reference_required?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
ffi-bit_masks' tests fail on JRuby. The change in this pull request fixes this.

Without this definition of `#reference_required?`, DataConverter's default implementation is used, which requires the object to be a module. Since each BitField is an instance of the BitField class, this check fails.
